### PR TITLE
feat: Configuração de variáveis de ambiente e atualização do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+## Configuração de Variáveis de Ambiente
+
+Antes de rodar a aplicação, é necessário configurar variáveis de ambiente para evitar expor credenciais sensíveis no código. Siga as instruções abaixo para configurar sua máquina:
+
+### Windows
+
+1. Pressione `Windows + S` e procure por **"Variáveis de Ambiente"**. Clique em **"Editar as Variáveis de Ambiente do Sistema"**.
+2. Na janela que abrir, clique em **"Variáveis de Ambiente"**.
+3. Adicione as seguintes variáveis na seção de **Variáveis do Usuário** ou **Variáveis do Sistema**:
+   - `DATABASE_URL`: `jdbc:postgresql://localhost:5432/seu_banco`
+   - `DATABASE_USERNAME`: `usuario`
+   - `DATABASE_PASSWORD`: `senha`
+4. Salve e reinicie o terminal ou IDE.
+
+### Linux
+
+1. Abra o arquivo do shell correspondente:
+   - Para Bash: `~/.bashrc`
+   - Para Zsh: `~/.zshrc`
+2. Adicione as seguintes linhas ao final do arquivo:
+- `export DATABASE_URL='jdbc:postgresql://localhost:5432/seu_banco'`
+- `export DATABASE_USERNAME='usuario'`
+- `export DATABASE_PASSWORD='senha'`
+3. Salve e rode o comando:
+
+
+### macOS
+
+1. Abra o arquivo do shell correspondente:
+- Para Bash: `~/.bash_profile`
+- Para Zsh (macOS Catalina ou mais recente): `~/.zshrc`
+2. Adicione as seguintes linhas:
+- `export DATABASE_URL='jdbc:postgresql://localhost:5432/seu_banco'`
+- `export DATABASE_USERNAME='usuario'`
+- `export DATABASE_PASSWORD='senha'`
+3. Salve e rode o comando:
+
+source `~/.bash_profile`
+ou source `~/.zshrc`
+
+
+### Executando a Aplicação
+
+Depois que as variáveis forem configuradas, você pode iniciar a aplicação normalmente. O Spring Boot automaticamente buscará as variáveis de ambiente e aplicará como configuração.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=rest-project
+spring.datasource.url=${DATABASE_URL}
+spring.datasource.username=${DATABASE_USERNAME}
+spring.datasource.password=${DATABASE_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
## O que foi feito:
- Configuração das variáveis de ambiente para armazenar credenciais sensíveis.
- Atualização do README.md com instruções detalhadas para configuração de variáveis no Windows, Linux e macOS.
- Testes realizados localmente para garantir que o Spring Boot captura as variáveis corretamente.

## Como testar:
1. Configure as variáveis de ambiente no Windows/Linux/macOS conforme o README.
2. Rode a aplicação e verifique se as variáveis são capturadas no Spring Boot.