### PR TITLE
feat: Criar Controller básico para CloudVendor

### DIFF
--- a/src/main/java/com/thinkproject/rest_project/controller/CloudVendorAPIService.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/CloudVendorAPIService.java
@@ -1,0 +1,18 @@
+package com.thinkproject.rest_project.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.thinkproject.rest_project.model.CloudVendor;
+
+@RestController
+@RequestMapping("/cloudvendor")
+public class CloudVendorAPIService
+{
+    @GetMapping("{vendorId}")
+    public CloudVendor getCloudVendorDetails(String vendorId)
+    {
+        return new CloudVendor("C1", "Vendor 1", "Address 1", "555-1234");
+    }
+}


### PR DESCRIPTION
## O que foi feito:
- Adicionado o Controller `CloudVendorAPIService` no pacote `controller`.
- Implementada a rota `/cloudvendor/{vendorId}` com suporte ao método GET.
- Atualmente, o Controller retorna um fornecedor de exemplo em formato JSON.

## Objetivo:
- Criar a base para o gerenciamento de fornecedores na aplicação.
- Configurar a estrutura inicial que será expandida para incluir lógica de serviço e banco de dados.

## Como testar:
1. Execute a aplicação localmente.
2. Acesse a URL: [http://localhost:8080/cloudvendor/C1](http://localhost:8080/cloudvendor/C1).
3. Verifique o retorno de um JSON com informações do fornecedor.