### PR TITLE
feat: Configurar integração com o banco de dados para CloudVendor

### DIFF
--- a/src/main/java/com/thinkproject/rest_project/controller/CloudVendorAPIService.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/CloudVendorAPIService.java
@@ -1,18 +1,28 @@
 package com.thinkproject.rest_project.controller;
 
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.thinkproject.rest_project.model.CloudVendor;
+import com.thinkproject.rest_project.repository.CloudVendorRepository;
 
 @RestController
 @RequestMapping("/cloudvendor")
 public class CloudVendorAPIService
 {
-    @GetMapping("{vendorId}")
-    public CloudVendor getCloudVendorDetails(String vendorId)
+    @Autowired
+    private CloudVendorRepository cloudVendorRepository;
+
+    @GetMapping("/{vendorId}")
+    public CloudVendor getCloudVendorDetails(@PathVariable("vendorId") String vendorId)
     {
-        return new CloudVendor("C1", "Vendor 1", "Address 1", "555-1234");
+        Optional<CloudVendor> cloudVendor = cloudVendorRepository.findById(vendorId);
+        
+        return cloudVendor.orElseThrow(() -> new RuntimeException("Vendor not found"));
     }
 }

--- a/src/main/java/com/thinkproject/rest_project/model/CloudVendor.java
+++ b/src/main/java/com/thinkproject/rest_project/model/CloudVendor.java
@@ -1,10 +1,25 @@
 package com.thinkproject.rest_project.model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "cloud_vendors")
 public class CloudVendor
 {
+    @Id
+    @Column(name = "vendor_id")
     private String vendorId;
+
+    @Column(name = "vendor_name", nullable = false)
     private String vendorName;
+
+    @Column(name = "vendor_address", nullable = false)
     private String vendorAddress;
+
+    @Column(name = "vendor_phone", nullable = false)
     private String vendorPhone;
     
     public CloudVendor() {

--- a/src/main/java/com/thinkproject/rest_project/repository/CloudVendorRepository.java
+++ b/src/main/java/com/thinkproject/rest_project/repository/CloudVendorRepository.java
@@ -1,0 +1,11 @@
+package com.thinkproject.rest_project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.thinkproject.rest_project.model.CloudVendor;
+
+@Repository
+public interface CloudVendorRepository extends JpaRepository<CloudVendor, String> {
+
+}


### PR DESCRIPTION
## O que foi feito:
1. Configurada a integração com o banco de dados para a entidade `CloudVendor`:
   - Ajustado o arquivo `application.properties` para usar variáveis de ambiente e configurado o Hibernate.
   - Adicionadas anotações JPA na classe `CloudVendor` para mapear a entidade como tabela no banco de dados.
2. Criado o repositório `CloudVendorRepository` para facilitar as operações CRUD.
3. Atualizado o Controller `CloudVendorAPIService`:
   - Criado o endpoint GET `/cloudvendor/{vendorId}` para buscar fornecedores do banco de dados.
   - Adicionado tratamento para retornar erro caso o fornecedor não seja encontrado.
4. Testes realizados localmente para confirmar a funcionalidade.

## Como testar:
1. Execute a aplicação.
2. Certifique-se de que o banco de dados está configurado corretamente.
3. Crie manualmente um registro no banco ou implemente o endpoint POST (isso será feito em uma etapa futura).
4. Acesse a URL: [http://localhost:8080/cloudvendor/{vendorId}](http://localhost:8080/cloudvendor/C1) substituindo `{vendorId}` pelo ID de um fornecedor existente.
5. O retorno deverá ser um objeto JSON contendo os detalhes do fornecedor.

## Próximos passos:
- Implementar o CRUD completo (POST, PUT e DELETE) para `CloudVendor`.
- Adicionar validações e tratamento de erros detalhados.
- Integrar o Lombok para reduzir boilerplate.