### PR TITLE
feat: Implementar CRUD completo para CloudVendor

### DIFF
--- a/src/main/java/com/thinkproject/rest_project/controller/CloudVendorAPIService.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/CloudVendorAPIService.java
@@ -3,8 +3,12 @@ package com.thinkproject.rest_project.controller;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,16 +17,44 @@ import com.thinkproject.rest_project.repository.CloudVendorRepository;
 
 @RestController
 @RequestMapping("/cloudvendor")
-public class CloudVendorAPIService
-{
+public class CloudVendorAPIService {
+
     @Autowired
     private CloudVendorRepository cloudVendorRepository;
 
     @GetMapping("/{vendorId}")
-    public CloudVendor getCloudVendorDetails(@PathVariable("vendorId") String vendorId)
-    {
+    public CloudVendor getCloudVendorDetails(@PathVariable("vendorId") Long vendorId) {
         Optional<CloudVendor> cloudVendor = cloudVendorRepository.findById(vendorId);
-        
+
         return cloudVendor.orElseThrow(() -> new RuntimeException("Vendor not found"));
+    }
+
+    @PostMapping
+    public CloudVendor createCloudVendor(@RequestBody CloudVendor cloudVendor) {
+        return cloudVendorRepository.save(cloudVendor);
+    }
+
+    @PutMapping("/{vendorId}")
+    public CloudVendor updateCloudVendor(@PathVariable("vendorId") Long vendorId,
+                                        @RequestBody CloudVendor cloudVendor) {
+        if (!cloudVendorRepository.existsById(vendorId)) {
+            throw new RuntimeException("Vendor not found");
+        }
+
+        cloudVendor = new CloudVendor(cloudVendor.getVendorName(), 
+                                    cloudVendor.getVendorAddress(), 
+                                    cloudVendor.getVendorPhone());
+        cloudVendor.setVendorId(vendorId);
+
+        return cloudVendorRepository.save(cloudVendor);
+    }
+
+    @DeleteMapping("/{vendorId}")
+    public String deleteCloudVendor(@PathVariable("vendorId") Long vendorId) {
+        if (!cloudVendorRepository.existsById(vendorId)) {
+            throw new RuntimeException("Vendor not found");
+        }
+        cloudVendorRepository.deleteById(vendorId);
+        return "Vendor deleted successfully";
     }
 }

--- a/src/main/java/com/thinkproject/rest_project/model/CloudVendor.java
+++ b/src/main/java/com/thinkproject/rest_project/model/CloudVendor.java
@@ -2,16 +2,19 @@ package com.thinkproject.rest_project.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "cloud_vendors")
-public class CloudVendor
-{
+public class CloudVendor {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "vendor_id")
-    private String vendorId;
+    private Long vendorId;
 
     @Column(name = "vendor_name", nullable = false)
     private String vendorName;
@@ -21,22 +24,21 @@ public class CloudVendor
 
     @Column(name = "vendor_phone", nullable = false)
     private String vendorPhone;
-    
+
     public CloudVendor() {
     }
 
-    public CloudVendor(String vendorAddress, String vendorId, String vendorName, String vendorPhone) {
-        this.vendorAddress = vendorAddress;
-        this.vendorId = vendorId;
+    public CloudVendor(String vendorName, String vendorAddress, String vendorPhone) {
         this.vendorName = vendorName;
+        this.vendorAddress = vendorAddress;
         this.vendorPhone = vendorPhone;
     }
 
-    public String getVendorId() {
+    public Long getVendorId() {
         return vendorId;
     }
 
-    public void setVendorId(String vendorId) {
+    public void setVendorId(Long vendorId) {
         this.vendorId = vendorId;
     }
 

--- a/src/main/java/com/thinkproject/rest_project/repository/CloudVendorRepository.java
+++ b/src/main/java/com/thinkproject/rest_project/repository/CloudVendorRepository.java
@@ -6,6 +6,6 @@ import org.springframework.stereotype.Repository;
 import com.thinkproject.rest_project.model.CloudVendor;
 
 @Repository
-public interface CloudVendorRepository extends JpaRepository<CloudVendor, String> {
-
+public interface CloudVendorRepository extends JpaRepository<CloudVendor, Long> {
 }
+


### PR DESCRIPTION
## O que foi feito:
- Adicionado CRUD completo para a entidade `CloudVendor`.
  - Método POST para criar fornecedores.
  - Método PUT para atualizar fornecedores.
  - Método DELETE para excluir fornecedores.
  - Método GET atualizado para buscar fornecedores do banco.
- Controller atualizado para centralizar as operações CRUD.
- Testado todos os endpoints usando Postman.
- Corrigido erro onde o método PUT criava um novo registro caso o vendorId não fosse passado no body.
- Atualizado o método PUT para definir explicitamente o ID antes de salvar a entidade.
- Garantido que `PUT /cloudvendor/{vendorId}` não crie um novo vendor se o ID estiver ausente no corpo da requisição.

## Como testar:
1. Configurar o banco de dados conforme `application.properties`.
2. Rodar a aplicação e usar os endpoints:
   - GET: `/cloudvendor/{vendorId}`
   - POST: `/cloudvendor`
   - PUT: `/cloudvendor/{vendorId}`
   - DELETE: `/cloudvendor/{vendorId}`

## Próximos passos:
- Adicionar validações específicas para os dados de entrada.
- Implementar tratamento de erros global com `@ControllerAdvice`.
- Refatorar com Lombok para reduzir a verbosidade do código.