### PR TITLE
feat: Adicionar documentação interativa com Swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.2.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
## O que foi feito:
- Configurado Swagger na aplicação para documentação interativa da API.
- Adicionada a dependência `springdoc-openapi-starter-webmvc-ui` ao projeto Maven.
- A documentação da API está disponível em: `/swagger-ui/index.html`.

## Objetivo:
- Facilitar o teste e a integração dos endpoints da API.
- Melhorar a comunicação com outras equipes e desenvolvedores.

## Como testar:
1. Execute a aplicação e acesse o Swagger: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html).
2. Teste os endpoints GET, POST, PUT e DELETE diretamente na interface interativa.

## Próximos passos:
- Melhorar a descrição dos endpoints com base nas regras de negócio.
- Adicionar suporte para autenticação JWT no Swagger (futuro).