### PR TITLE
feat: Implementar autenticação JWT para proteção de endpoints

### DIFF
--- a/src/main/java/com/thinkproject/rest_project/config/SecurityConfig.java
+++ b/src/main/java/com/thinkproject/rest_project/config/SecurityConfig.java
@@ -10,24 +10,28 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import static org.springframework.security.config.Customizer.withDefaults;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.thinkproject.rest_project.filter.JwtAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http.csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/auth/**").permitAll()
                 .anyRequest().authenticated()
             )
-            .httpBasic(withDefaults()); // Corrigido: agora usa withDefaults()
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+            .httpBasic(withDefaults());
         return http.build();
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder(); // Para criptografar senhas
+        return new BCryptPasswordEncoder();
     }
 
     @Bean

--- a/src/main/java/com/thinkproject/rest_project/controller/AuthController.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.thinkproject.rest_project.controller;
 
 import com.thinkproject.rest_project.model.User;
 import com.thinkproject.rest_project.repository.UserRepository;
+import com.thinkproject.rest_project.util.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +19,9 @@ public class AuthController {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtUtil jwtUtil;
 
     @PostMapping("/register")
     public Map<String, String> register(@RequestBody User user) {
@@ -43,10 +47,11 @@ public class AuthController {
             throw new RuntimeException("Usuário ou senha inválidos!");
         }
 
+        String token = jwtUtil.generateToken(existingUser.getUsername());
+
         Map<String, String> response = new HashMap<>();
         response.put("message", "Login realizado com sucesso!");
-        response.put("username", existingUser.getUsername());
-        response.put("role", existingUser.getRole());
+        response.put("token", token);
         return response;
     }
 }

--- a/src/main/java/com/thinkproject/rest_project/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/thinkproject/rest_project/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,38 @@
+package com.thinkproject.rest_project.filter;
+
+import com.thinkproject.rest_project.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, jakarta.servlet.ServletException {
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            String username = jwtUtil.extractUsername(token);
+
+            if (jwtUtil.validateToken(token) && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(username, null, null);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/thinkproject/rest_project/util/JwtUtil.java
+++ b/src/main/java/com/thinkproject/rest_project/util/JwtUtil.java
@@ -1,0 +1,47 @@
+package com.thinkproject.rest_project.util;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private static final String SECRET_KEY = "mysecretkeymysecretkeymysecretkeymysecretkey"; // Chave secreta (deve ter pelo menos 32 caracteres)
+    private static final long EXPIRATION_TIME = 86400000; // 1 dia em milissegundos
+
+    private final Key key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+
+    public String generateToken(String username) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + EXPIRATION_TIME);
+
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(key)
+                .compact();
+    }
+
+    public String extractUsername(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## O que foi feito:
- Adicionada a autenticação baseada em JWT (JSON Web Token) para proteger os endpoints da API.
- Implementadas as seguintes alterações:
  1. **Integrada a biblioteca `jjwt` para geração e validação de tokens JWT.**
  2. **Criada a classe `JwtUtil`**:
     - Gera tokens JWT com base no username.
     - Valida e extrai informações dos tokens JWT.
  3. **Atualizado o endpoint `POST /auth/login`**:
     - Retorna um token JWT no corpo da resposta após autenticar com sucesso.
  4. **Criado o filtro `JwtAuthenticationFilter`**:
     - Valida o token JWT em cada requisição protegida.
     - Configura o contexto de segurança no Spring Security.
  5. **Atualizado o arquivo `SecurityConfig`**:
     - Registrado o filtro JWT para proteger endpoints.
     - Permissão de acesso público para rotas do Swagger e `/auth/**`.
     - Proteção de qualquer outra rota com autenticação obrigatória.

## Objetivo:
- Fortalecer a segurança da API, permitindo acesso somente a usuários autenticados.
- Proteger todos os endpoints, exceto os rotas públicas (Swagger e autenticação).

## Como testar:
1. Registre um novo usuário na rota `POST /auth/register`.
2. Faça login na rota `POST /auth/login` com o usuário registrado e receba o token JWT.
3. Teste os endpoints protegidos, enviando o token no cabeçalho da requisição:
- Authorization: Bearer <seu-token-jwt>
4. Teste o comportamento usando tokens inválidos ou expirados:
- O servidor deve retornar erro 401 (não autorizado).

## Próximos passos:
- Gerenciar expiração e renovação de tokens JWT.
- Adicionar suporte para papéis de usuário (roles) como `ADMIN` e `USER`, protegendo endpoints específicos com base no papel.
- Melhorar o tratamento de erros global da API.

## Links úteis:
- [Como usar tokens JWT](https://jwt.io/)
- [Documentação do Spring Security](https://docs.spring.io/spring-security/reference/index.html)
