### PR TITLE
feat: Gerenciar expiração e renovação de tokens JWT e suporte para papéis de usuário

### DIFF
--- a/src/main/java/com/thinkproject/rest_project/config/SecurityConfig.java
+++ b/src/main/java/com/thinkproject/rest_project/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.thinkproject.rest_project.config;
 
+import com.thinkproject.rest_project.filter.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -8,24 +9,21 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-
-import static org.springframework.security.config.Customizer.withDefaults;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
-import com.thinkproject.rest_project.filter.JwtAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
-        http.csrf(csrf -> csrf.disable())
+        http
+            .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/auth/**").permitAll()
+                .requestMatchers("/admin/**").hasAuthority("ROLE_ADMIN")
                 .anyRequest().authenticated()
             )
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-            .httpBasic(withDefaults());
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/thinkproject/rest_project/controller/AuthController.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/AuthController.java
@@ -29,8 +29,13 @@ public class AuthController {
             throw new RuntimeException("Username já existe!");
         }
 
+        String role = user.getRole();
+        if (role == null || (!role.equalsIgnoreCase("USER") && !role.equalsIgnoreCase("ADMIN"))) {
+            throw new RuntimeException("Papel inválido! Use 'USER' ou 'ADMIN'.");
+        }
+
         user.setPassword(passwordEncoder.encode(user.getPassword()));
-        user.setRole("USER");
+        user.setRole(role.toUpperCase());
         userRepository.save(user);
 
         Map<String, String> response = new HashMap<>();
@@ -52,6 +57,27 @@ public class AuthController {
         Map<String, String> response = new HashMap<>();
         response.put("message", "Login realizado com sucesso!");
         response.put("token", token);
+        return response;
+    }
+
+    @PostMapping("/renew-token")
+    public Map<String, String> renewToken(@RequestHeader("Authorization") String token) {
+        if (!token.startsWith("Bearer ")) {
+            throw new RuntimeException("Token inválido!");
+        }
+
+        token = token.substring(7);
+
+        if (!jwtUtil.validateToken(token) || jwtUtil.isTokenExpired(token)) {
+            throw new RuntimeException("Token inválido ou expirado!");
+        }
+
+        String username = jwtUtil.extractUsername(token);
+        String newToken = jwtUtil.generateToken(username);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "Token renovado com sucesso!");
+        response.put("token", newToken);
         return response;
     }
 }

--- a/src/main/java/com/thinkproject/rest_project/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/thinkproject/rest_project/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,11 @@
 package com.thinkproject.rest_project.filter;
 
+import com.thinkproject.rest_project.model.User;
+import com.thinkproject.rest_project.repository.UserRepository;
 import com.thinkproject.rest_project.util.JwtUtil;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -11,6 +15,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import jakarta.servlet.http.*;
 import jakarta.servlet.*;
 import java.io.IOException;
+import java.util.List;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -18,8 +23,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Autowired
     private JwtUtil jwtUtil;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, jakarta.servlet.ServletException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
         String authHeader = request.getHeader("Authorization");
 
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
@@ -27,8 +35,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String username = jwtUtil.extractUsername(token);
 
             if (jwtUtil.validateToken(token) && SecurityContextHolder.getContext().getAuthentication() == null) {
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(username, null, null);
+                User user = userRepository.findByUsername(username)
+                        .orElseThrow(() -> new RuntimeException("Usuário não encontrado!"));
+
+                SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + user.getRole());
+
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        username,
+                        null,
+                        List.of(authority)
+                );
+
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         }

--- a/src/main/java/com/thinkproject/rest_project/util/JwtUtil.java
+++ b/src/main/java/com/thinkproject/rest_project/util/JwtUtil.java
@@ -10,7 +10,7 @@ import java.util.Date;
 @Component
 public class JwtUtil {
 
-    private static final String SECRET_KEY = "mysecretkeymysecretkeymysecretkeymysecretkey"; // Chave secreta (deve ter pelo menos 32 caracteres)
+    private static final String SECRET_KEY = "mysecretkeymysecretkeymysecretkeymysecretkey";
     private static final long EXPIRATION_TIME = 86400000; // 1 dia em milissegundos
 
     private final Key key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
@@ -43,5 +43,15 @@ public class JwtUtil {
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
+    }
+
+    public boolean isTokenExpired(String token) {
+        Date expirationDate = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+        return expirationDate.before(new Date());
     }
 }


### PR DESCRIPTION
## O que foi feito:
1. **Suporte à expiração e renovação de tokens JWT:**
   - Tokens JWT agora possuem um prazo de validade (1 dia por padrão).
   - Criado o endpoint `/auth/renew-token` para renovar tokens JWT válidos antes de expirar.
   - Adicionado método no `JwtUtil` para verificar se um token já expirou.

2. **Implementado suporte a papéis de usuário:**
   - Atualizada a entidade `User` com o campo `role` para diferenciar permissões (`USER` e `ADMIN`).
   - Atualizado o filtro `JwtAuthenticationFilter` para buscar o papel do usuário no banco de dados e incluí-lo no contexto de segurança (`SecurityContextHolder`).
   - Restringidos endpoints no `SecurityConfig` com base nos papéis:
     - Acesso a `/admin/**` permitido apenas para `ADMIN`.
     - Acesso às demais rotas protegido por autenticação JWT.

3. **Melhorias no endpoint `/auth/register`:**
   - Ajustado o código para registrar corretamente o papel (`role`) enviado na requisição.
   - Criada validação para aceitar apenas os papéis válidos (`USER` ou `ADMIN`).
   - Evitado sobrescrever o papel com valores fixos.

4. **Criado endpoint para teste de papéis:**
   - Endpoint `/admin/test` criado como exemplo de rota restrita apenas para usuários com o papel `ADMIN`.

---

## Como testar:
### Fluxo de autenticação:
1. Registre dois usuários com papéis diferentes (`ADMIN` e `USER`) usando o endpoint `POST /auth/register`.
   - Exemplo de requisições:
     ```
     {
       "username": "admin",
       "password": "admin123",
       "role": "ADMIN"
     }
     ```
     ```
     {
       "username": "user",
       "password": "user123",
       "role": "USER"
     }
     ```

2. Faça login com cada usuário usando `POST /auth/login` e receba os tokens JWT.

3. Tente acessar os endpoints protegidos com os tokens gerados:
   - Usuário com papel `USER`:
     - Deve ter acesso negado (`403 Forbidden`) ao acessar `/admin/test`.
   - Usuário com papel `ADMIN`:
     - Deve acessar `/admin/test` com sucesso.

### Renovação de token JWT:
1. Gere um token JWT ao fazer login e chame o endpoint `POST /auth/renew-token` antes de o token expirar.
2. Envie o token no cabeçalho `Authorization`:
  - Authorization: Bearer <seu-token-jwt>
3. Receba um novo token JWT com validade renovada.

---

## Próximos passos:
- Melhorar o tratamento de erros e mensagens de retorno, especialmente para casos como tokens inválidos ou expirados.
- Implementar testes automatizados para validar autenticação, autorização e proteção de endpoints.