### PR TITLE
docs: Adicionar anotações do Swagger ao AuthController

### DIFF
--- a/src/main/java/com/thinkproject/rest_project/controller/AuthController.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/AuthController.java
@@ -3,6 +3,10 @@ package com.thinkproject.rest_project.controller;
 import com.thinkproject.rest_project.model.User;
 import com.thinkproject.rest_project.repository.UserRepository;
 import com.thinkproject.rest_project.util.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
@@ -23,8 +27,18 @@ public class AuthController {
     @Autowired
     private JwtUtil jwtUtil;
 
+    @Operation(
+        summary = "Registrar um novo usuário",
+        description = "Permite registrar um novo usuário no sistema, fornecendo um username, senha e papel (USER ou ADMIN)."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Usuário registrado com sucesso"),
+        @ApiResponse(responseCode = "400", description = "Username já existe ou papel inválido")
+    })
     @PostMapping("/register")
-    public Map<String, String> register(@RequestBody User user) {
+    public Map<String, String> register(
+        @Parameter(description = "Detalhes do usuário para registro (username, password, role)", required = true)
+        @RequestBody User user) {
         if (userRepository.findByUsername(user.getUsername()).isPresent()) {
             throw new RuntimeException("Username já existe!");
         }
@@ -43,8 +57,18 @@ public class AuthController {
         return response;
     }
 
+    @Operation(
+        summary = "Fazer login",
+        description = "Autentica o usuário no sistema e retorna um token JWT para ser usado em endpoints protegidos."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Login realizado com sucesso"),
+        @ApiResponse(responseCode = "401", description = "Usuário ou senha inválidos")
+    })
     @PostMapping("/login")
-    public Map<String, String> login(@RequestBody User user) {
+    public Map<String, String> login(
+        @Parameter(description = "Credenciais para autenticação (username e password)", required = true)
+        @RequestBody User user) {
         User existingUser = userRepository.findByUsername(user.getUsername())
                 .orElseThrow(() -> new RuntimeException("Usuário ou senha inválidos!"));
 
@@ -60,8 +84,18 @@ public class AuthController {
         return response;
     }
 
+    @Operation(
+        summary = "Renovar token JWT",
+        description = "Permite renovar um token JWT válido antes de ele expirar, retornando um novo token atualizado."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Token renovado com sucesso"),
+        @ApiResponse(responseCode = "401", description = "Token inválido ou expirado")
+    })
     @PostMapping("/renew-token")
-    public Map<String, String> renewToken(@RequestHeader("Authorization") String token) {
+    public Map<String, String> renewToken(
+        @Parameter(description = "Token JWT atual no cabeçalho Authorization com o formato 'Bearer {token}'", required = true)
+        @RequestHeader("Authorization") String token) {
         if (!token.startsWith("Bearer ")) {
             throw new RuntimeException("Token inválido!");
         }


### PR DESCRIPTION
## O que foi feito:
- Adicionadas anotações do Swagger no `AuthController` para melhorar a documentação dos seguintes endpoints:
  1. **`POST /auth/register`:**
     - Documentado o objetivo do endpoint: registrar usuários no sistema.
     - Descritos os parâmetros esperados no corpo da requisição (`username`, `password`, `role`) e as respostas possíveis (`200`, `400`).
  2. **`POST /auth/login`:**
     - Documentado o objetivo: autenticar usuários e gerar token JWT.
     - Descritos os parâmetros esperados (`username`, `password`) e as respostas possíveis (`200`, `401`).
  3. **`POST /auth/renew-token`:**
     - Documentado o objetivo: renovar tokens JWT válidos antes de expirar.
     - Descrito o cabeçalho esperado (`Authorization: Bearer {token}`) e as respostas possíveis (`200`, `401`).

## Objetivo:
- Melhorar a documentação e usabilidade da API ao integrar as descrições dos endpoints na interface do Swagger.
- Facilitar o entendimento de como usar os serviços de autenticação (registro, login e renovação de tokens) por outros desenvolvedores ou equipes de integração.

## Como testar:
1. Inicie a aplicação e acesse o Swagger:
http://localhost:8080/swagger-ui/index.html
2. Verifique a documentação dos endpoints no grupo `/auth`:
- **`POST /auth/register`:** Deve mostrar o objetivo, parâmetros esperados (`username`, `password`, `role`) e respostas (`200`, `400`).
- **`POST /auth/login`:** Deve mostrar o objetivo, parâmetros esperados e respostas (`200`, `401`).
- **`POST /auth/renew-token`:** Deve mostrar o objetivo, o cabeçalho esperado (`Authorization: Bearer {token}`) e respostas (`200`, `401`).

## Próximos passos:
- Adicionar validações mais detalhadas na API para tratamento de erros específicos (ex.: formulários incompletos, campos inválidos).
- Expandir a documentação Swagger para outros controllers da aplicação.