### PR TITLE
feat: Adicionar entidade CloudService e relacioná-la com CloudVendor

### DIFF
--- a/src/main/java/com/thinkproject/rest_project/config/SecurityConfig.java
+++ b/src/main/java/com/thinkproject/rest_project/config/SecurityConfig.java
@@ -1,3 +1,4 @@
+//SecurityConfig.java
 package com.thinkproject.rest_project.config;
 
 import com.thinkproject.rest_project.filter.JwtAuthenticationFilter;

--- a/src/main/java/com/thinkproject/rest_project/controller/AuthController.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/AuthController.java
@@ -1,3 +1,4 @@
+//AuthController.java
 package com.thinkproject.rest_project.controller;
 
 import com.thinkproject.rest_project.model.User;

--- a/src/main/java/com/thinkproject/rest_project/controller/CloudServiceController.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/CloudServiceController.java
@@ -1,0 +1,27 @@
+//CloudServiceController.java
+package com.thinkproject.rest_project.controller;
+
+import com.thinkproject.rest_project.model.CloudService;
+import com.thinkproject.rest_project.repository.CloudServiceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/cloudservice")
+public class CloudServiceController {
+
+    @Autowired
+    private CloudServiceRepository cloudServiceRepository;
+
+    @GetMapping
+    public List<CloudService> getAllServices() {
+        return cloudServiceRepository.findAll();
+    }
+
+    @PostMapping
+    public CloudService createService(@RequestBody CloudService cloudService) {
+        return cloudServiceRepository.save(cloudService);
+    }
+}

--- a/src/main/java/com/thinkproject/rest_project/controller/CloudVendorAPIService.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/CloudVendorAPIService.java
@@ -1,3 +1,4 @@
+//CloudVendorAPIService.java
 package com.thinkproject.rest_project.controller;
 
 import java.util.Optional;

--- a/src/main/java/com/thinkproject/rest_project/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/thinkproject/rest_project/filter/JwtAuthenticationFilter.java
@@ -1,3 +1,4 @@
+//JwtAuthenticationFilter.java
 package com.thinkproject.rest_project.filter;
 
 import com.thinkproject.rest_project.model.User;

--- a/src/main/java/com/thinkproject/rest_project/model/CloudService.java
+++ b/src/main/java/com/thinkproject/rest_project/model/CloudService.java
@@ -1,0 +1,30 @@
+//CloudService.java
+package com.thinkproject.rest_project.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cloud_services")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CloudService {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "service_id")
+    private Long id;
+
+    @Column(name = "service_name", nullable = false)
+    private String name;
+
+    @Column(name = "service_description", nullable = false)
+    private String description;
+
+    @ManyToOne
+    @JoinColumn(name = "vendor_id", nullable = false)
+    private CloudVendor vendor; // Relacionamento Many-to-One
+}

--- a/src/main/java/com/thinkproject/rest_project/model/CloudVendor.java
+++ b/src/main/java/com/thinkproject/rest_project/model/CloudVendor.java
@@ -1,4 +1,8 @@
+//CloudVendor.java
 package com.thinkproject.rest_project.model;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -29,4 +33,8 @@ public class CloudVendor {
         this.vendorAddress = vendorAddress;
         this.vendorPhone = vendorPhone;
     }
+
+    @OneToMany(mappedBy = "vendor", cascade = CascadeType.ALL)
+    private List<CloudService> services = new ArrayList<>();
+    
 }

--- a/src/main/java/com/thinkproject/rest_project/model/User.java
+++ b/src/main/java/com/thinkproject/rest_project/model/User.java
@@ -1,3 +1,4 @@
+//User.java
 package com.thinkproject.rest_project.model;
 
 import jakarta.persistence.*;

--- a/src/main/java/com/thinkproject/rest_project/repository/CloudServiceRepository.java
+++ b/src/main/java/com/thinkproject/rest_project/repository/CloudServiceRepository.java
@@ -1,0 +1,9 @@
+//CloudServiceRepository.java
+
+package com.thinkproject.rest_project.repository;
+
+import com.thinkproject.rest_project.model.CloudService;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CloudServiceRepository extends JpaRepository<CloudService, Long> {
+}

--- a/src/main/java/com/thinkproject/rest_project/repository/CloudVendorRepository.java
+++ b/src/main/java/com/thinkproject/rest_project/repository/CloudVendorRepository.java
@@ -1,3 +1,4 @@
+//CloudVendorRepository.java
 package com.thinkproject.rest_project.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/thinkproject/rest_project/repository/UserRepository.java
+++ b/src/main/java/com/thinkproject/rest_project/repository/UserRepository.java
@@ -1,3 +1,4 @@
+//UserRepository.java
 package com.thinkproject.rest_project.repository;
 
 import com.thinkproject.rest_project.model.User;

--- a/src/main/java/com/thinkproject/rest_project/util/JwtUtil.java
+++ b/src/main/java/com/thinkproject/rest_project/util/JwtUtil.java
@@ -1,3 +1,4 @@
+//JwtUtil.java
 package com.thinkproject.rest_project.util;
 
 import io.jsonwebtoken.*;


### PR DESCRIPTION
## O que foi feito:
1. **Entidade `CloudService`:**
   - Criada a classe `CloudService` para representar os serviços ofertados por fornecedores na nuvem.
   - Adicionado relacionamento `@ManyToOne` entre `CloudService` e `CloudVendor`, com a coluna `vendor_id` como chave estrangeira.
   - Incluídos os campos:
     - `id` (identificador único para o serviço).
     - `name` (nome do serviço oferecido).
     - `description` (descrição do serviço).
     - `vendor` (referência ao fornecedor relacionado).

2. **Atualização em `CloudVendor`:**
   - Atualizada a entidade `CloudVendor` para incluir o relacionamento `@OneToMany` com `CloudService`.
   - Adicionado o campo `services`, representando a lista de serviços fornecidos.

3. **Repositório para `CloudService`:**
   - Criado o `CloudServiceRepository` para manipulação dos serviços no banco de dados.

4. **Controller para `CloudService`:**
   - Implementados os endpoints básicos no `CloudServiceController`:
     - **`GET /cloudservice`:** Retorna todos os serviços disponíveis.
     - **`POST /cloudservice`:** Cria um novo serviço associado a um fornecedor existente.

## Motivo:
- Expandir o domínio da API para incluir a gestão de serviços oferecidos por fornecedores, configurando um relacionamento `One-to-Many` entre `CloudVendor` e `CloudService`.

## Como testar:
1. Registre um novo fornecedor (CloudVendor) através do endpoint `/cloudvendor`.
2. Crie um serviço associado ao fornecedor através do endpoint `POST /cloudservice` com o seguinte JSON:

  {
  "name": "Banco de Dados",
  "description": "Serviço de banco de dados relacional",
  "vendor": {
  "vendorId": 1
  }
  }

4. Liste todos os serviços existentes através do endpoint `GET /cloudservice`.

## Próximos passos:
- Adicionar validações nos endpoints.
- Criar a entidade `Client` e o relacionamento `Many-to-Many` com `CloudService`.