### PR TITLE
feat: Adicionar suporte a clientes e contratos de uso, com relacionamentos Many-to-Many entre Client e CloudService

### DIFF
--- a/src/main/java/com/thinkproject/rest_project/config/SecurityConfig.java
+++ b/src/main/java/com/thinkproject/rest_project/config/SecurityConfig.java
@@ -2,6 +2,7 @@
 package com.thinkproject.rest_project.config;
 
 import com.thinkproject.rest_project.filter.JwtAuthenticationFilter;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -12,7 +13,27 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+
 @Configuration
+@OpenAPIDefinition(
+    info = @Info(
+        title = "API RESTful com Spring Boot e JWT",
+        version = "1.0",
+        description = "Documentação da API para gerenciamento de Cloud Vendors, Clientes e Contratos."
+    ),
+    security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+    name = "bearerAuth",
+    type = SecuritySchemeType.HTTP,
+    scheme = "bearer",
+    bearerFormat = "JWT"
+)
 public class SecurityConfig {
 
     @Bean
@@ -38,3 +59,4 @@ public class SecurityConfig {
         return authenticationConfiguration.getAuthenticationManager();
     }
 }
+

--- a/src/main/java/com/thinkproject/rest_project/controller/AuthController.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/AuthController.java
@@ -116,3 +116,4 @@ public class AuthController {
         return response;
     }
 }
+

--- a/src/main/java/com/thinkproject/rest_project/controller/ClientController.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/ClientController.java
@@ -1,0 +1,54 @@
+package com.thinkproject.rest_project.controller;
+
+import com.thinkproject.rest_project.model.Client;
+import com.thinkproject.rest_project.repository.ClientRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+@RestController
+@RequestMapping("/clients")
+@SecurityRequirement(name = "bearerAuth")
+public class ClientController {
+
+    @Autowired
+    private ClientRepository clientRepository;
+
+    @Operation(
+        summary = "Listar todos os clientes",
+        description = "Retorna uma lista de todos os clientes cadastrados no sistema."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Lista de clientes retornada com sucesso"),
+        @ApiResponse(responseCode = "500", description = "Erro interno no servidor")
+    })
+    @GetMapping
+    public List<Client> getAllClients() {
+        return clientRepository.findAll();
+    }
+
+    @Operation(
+        summary = "Criar um novo cliente",
+        description = "Adiciona um novo cliente ao sistema com as informações fornecidas."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "Cliente criado com sucesso"),
+        @ApiResponse(responseCode = "400", description = "Solicitação inválida (exemplo: campos obrigatórios ausentes)"),
+        @ApiResponse(responseCode = "500", description = "Erro interno ao salvar o cliente")
+    })
+    @PostMapping
+    public Client createClient(
+        @Parameter(description = "Detalhes do cliente a ser criado", required = true)
+        @RequestBody Client client) {
+        return clientRepository.save(client);
+    }
+}

--- a/src/main/java/com/thinkproject/rest_project/controller/CloudServiceController.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/CloudServiceController.java
@@ -1,27 +1,54 @@
-//CloudServiceController.java
 package com.thinkproject.rest_project.controller;
 
 import com.thinkproject.rest_project.model.CloudService;
 import com.thinkproject.rest_project.repository.CloudServiceRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
 @RestController
 @RequestMapping("/cloudservice")
+@SecurityRequirement(name = "bearerAuth")
 public class CloudServiceController {
 
     @Autowired
     private CloudServiceRepository cloudServiceRepository;
 
+    @Operation(
+        summary = "Listar todos os serviços",
+        description = "Retorna uma lista de todos os serviços de nuvem cadastrados no sistema."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Lista de serviços retornada com sucesso"),
+        @ApiResponse(responseCode = "500", description = "Erro interno no servidor")
+    })
     @GetMapping
     public List<CloudService> getAllServices() {
         return cloudServiceRepository.findAll();
     }
 
+    @Operation(
+        summary = "Criar um novo serviço de nuvem",
+        description = "Adiciona um novo serviço ao sistema com as informações fornecidas."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "Serviço criado com sucesso"),
+        @ApiResponse(responseCode = "400", description = "Solicitação inválida (exemplo: campos obrigatórios ausentes)"),
+        @ApiResponse(responseCode = "500", description = "Erro interno ao salvar o serviço")
+    })
     @PostMapping
-    public CloudService createService(@RequestBody CloudService cloudService) {
+    public CloudService createService(
+        @Parameter(description = "Detalhes do serviço a ser criado", required = true)
+        @RequestBody CloudService cloudService) {
         return cloudServiceRepository.save(cloudService);
     }
 }

--- a/src/main/java/com/thinkproject/rest_project/controller/CloudVendorAPIService.java
+++ b/src/main/java/com/thinkproject/rest_project/controller/CloudVendorAPIService.java
@@ -8,11 +8,14 @@ import com.thinkproject.rest_project.repository.CloudVendorRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 @RestController
 @RequestMapping("/cloudvendor")
+@SecurityRequirement(name = "bearerAuth")
 public class CloudVendorAPIService {
 
     @Autowired
@@ -67,3 +70,4 @@ public class CloudVendorAPIService {
         return "Vendor deleted successfully";
     }
 }
+

--- a/src/main/java/com/thinkproject/rest_project/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/thinkproject/rest_project/filter/JwtAuthenticationFilter.java
@@ -56,3 +56,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 }
+

--- a/src/main/java/com/thinkproject/rest_project/model/Client.java
+++ b/src/main/java/com/thinkproject/rest_project/model/Client.java
@@ -1,0 +1,31 @@
+package com.thinkproject.rest_project.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "clients")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Client {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "client_id")
+    private Long id;
+
+    @Column(name = "client_name", nullable = false)
+    private String name;
+
+    @Column(name = "client_email", nullable = false, unique = true)
+    private String email;
+
+    @OneToMany(mappedBy = "client", cascade = CascadeType.ALL)
+    private List<UsageContract> contracts = new ArrayList<>(); // Relacionamento com UsageContract
+}

--- a/src/main/java/com/thinkproject/rest_project/model/CloudService.java
+++ b/src/main/java/com/thinkproject/rest_project/model/CloudService.java
@@ -1,6 +1,9 @@
 //CloudService.java
 package com.thinkproject.rest_project.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -27,4 +30,9 @@ public class CloudService {
     @ManyToOne
     @JoinColumn(name = "vendor_id", nullable = false)
     private CloudVendor vendor; // Relacionamento Many-to-One
+
+    @OneToMany(mappedBy = "service", cascade = CascadeType.ALL)
+    private List<UsageContract> contracts = new ArrayList<>();
+
 }
+

--- a/src/main/java/com/thinkproject/rest_project/model/CloudVendor.java
+++ b/src/main/java/com/thinkproject/rest_project/model/CloudVendor.java
@@ -38,3 +38,4 @@ public class CloudVendor {
     private List<CloudService> services = new ArrayList<>();
     
 }
+

--- a/src/main/java/com/thinkproject/rest_project/model/UsageContract.java
+++ b/src/main/java/com/thinkproject/rest_project/model/UsageContract.java
@@ -1,0 +1,38 @@
+package com.thinkproject.rest_project.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Table(name = "usage_contracts")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsageContract {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "contract_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "client_id", nullable = false)
+    private Client client; // Relacionamento Many-to-One com Client
+
+    @ManyToOne
+    @JoinColumn(name = "service_id", nullable = false)
+    private CloudService service; // Relacionamento Many-to-One com CloudService
+
+    @Column(name = "start_date", nullable = false)
+    private Date startDate;
+
+    @Column(name = "end_date")
+    private Date endDate;
+
+    @Column(name = "status", nullable = false)
+    private String status; // Ex.: "ACTIVE", "CANCELLED"
+}

--- a/src/main/java/com/thinkproject/rest_project/model/User.java
+++ b/src/main/java/com/thinkproject/rest_project/model/User.java
@@ -24,5 +24,6 @@ public class User {
     private String password;
 
     @Column(nullable = false)
-    private String role; // Ex: "USER" ou "ADMIN"
+    private String role;
 }
+

--- a/src/main/java/com/thinkproject/rest_project/repository/ClientRepository.java
+++ b/src/main/java/com/thinkproject/rest_project/repository/ClientRepository.java
@@ -1,0 +1,7 @@
+package com.thinkproject.rest_project.repository;
+
+import com.thinkproject.rest_project.model.Client;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClientRepository extends JpaRepository<Client, Long> {
+}

--- a/src/main/java/com/thinkproject/rest_project/repository/CloudServiceRepository.java
+++ b/src/main/java/com/thinkproject/rest_project/repository/CloudServiceRepository.java
@@ -7,3 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CloudServiceRepository extends JpaRepository<CloudService, Long> {
 }
+

--- a/src/main/java/com/thinkproject/rest_project/repository/UsageContractRepository.java
+++ b/src/main/java/com/thinkproject/rest_project/repository/UsageContractRepository.java
@@ -1,0 +1,7 @@
+package com.thinkproject.rest_project.repository;
+
+import com.thinkproject.rest_project.model.UsageContract;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UsageContractRepository extends JpaRepository<UsageContract, Long> {
+}

--- a/src/main/java/com/thinkproject/rest_project/repository/UserRepository.java
+++ b/src/main/java/com/thinkproject/rest_project/repository/UserRepository.java
@@ -11,3 +11,4 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 }
+

--- a/src/main/java/com/thinkproject/rest_project/util/JwtUtil.java
+++ b/src/main/java/com/thinkproject/rest_project/util/JwtUtil.java
@@ -56,3 +56,4 @@ public class JwtUtil {
         return expirationDate.before(new Date());
     }
 }
+


### PR DESCRIPTION
## O que foi feito:

### **1. Modelagem do Banco de Dados**
- **Criada a entidade `Client`:**
  - Representa os clientes do sistema, com atributos como `name` e `email`.
  - Relacionamento `One-to-Many` com a entidade intermediária `UsageContract`.
- **Criada a entidade `UsageContract`:**
  - Entidade intermediária para conectar `Client` e `CloudService` em um relacionamento Many-to-Many.
  - Contém informações adicionais:
    - `startDate`: Data de início do contrato.
    - `endDate`: Data de encerramento do contrato.
    - `status`: Representa o status do contrato (ex.: "ACTIVE", "CANCELLED").
  - Relacionamentos:
    - Many-to-One com `Client`.
    - Many-to-One com `CloudService`.
- **Atualizada a entidade `CloudService`:**
  - Relacionamento One-to-Many com `UsageContract`.

### **2. CRUD para Clientes**
- Criado o `ClientController` com endpoints básicos para `Client`:
  - `GET /clients`: Lista todos os clientes.
  - `POST /clients`: Cria um novo cliente (requer autenticação JWT).
- Criado o `ClientRepository` para gerenciar operações no banco de dados para `Client`.

### **3. Suporte a Autenticação JWT no Swagger**
- Criada a classe `SwaggerConfig` para habilitar autenticação via token JWT na interface do Swagger:
  - Adicionado botão "Authorize" para inserir o token JWT.
  - Atualizados os controladores (ex.: `ClientController`) com `@SecurityRequirement` para indicar que os endpoints exigem autenticação.
- Testados os endpoints no Swagger para garantir que o token JWT seja enviado corretamente no cabeçalho `Authorization`.

### **4. Anotações do Swagger**
- Adicionadas anotações detalhadas nos controladores `ClientController` e `CloudServiceController`:
  - `@Operation`, `@Parameter` e `@ApiResponses` foram usados para descrever:
    - O propósito dos endpoints.
    - Os parâmetros esperados.
    - As respostas possíveis (ex.: `200`, `400`, `500`).
  - Documentados endpoints como:
    - `GET /clients`: Retorna uma lista de clientes.
    - `POST /clients`: Cria um novo cliente.
    - `GET /cloudservice`: Retorna uma lista de serviços na nuvem.
    - `POST /cloudservice`: Cria um novo serviço.

### **5. Testado o Fluxo Completo**
- Gerado token JWT para usuários autenticados usando o endpoint `/auth/login`.
- Verificado o fluxo de autenticação e autorização para acessar endpoints protegidos.
- Verificado o funcionamento do Swagger após a configuração do suporte JWT.

---

## Como testar:

### **1. Criar um Cliente**
- Endpoint: `POST /clients`
- Corpo da requisição:
  ```
  {
  "name": "Cliente Exemplo",
  "email": "[cliente@example.com](mailto:cliente@example.com)"
  }
  ```
- Resposta esperada:
  ```
  {
  "id": 1,
  "name": "Cliente Exemplo",
  "email": "[cliente@example.com](mailto:cliente@example.com)",
  "contracts": []
  }
  ```

### **2. Listar Clientes**
- Endpoint: `GET /clients`.
- Resposta esperada:
  ```
  [
  {
  "id": 1,
  "name": "Cliente Exemplo",
  "email": "[cliente@example.com](mailto:cliente@example.com)",
  "contracts": []
  }
  ]
  ```
### **3. Testar Endpoints Protegidos**
- Geração de token:
- Faça login usando o endpoint `POST /auth/login`:
  ```
  {
    "username": "admin",
    "password": "admin123"
  }
  ```
  Retorno esperado:
  ```
  {
    "message": "Login realizado com sucesso!",
    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6..."
  }
  ```
- Adicionar o token no botão "Authorize" do Swagger UI.
- Testar o acesso aos endpoints protegidos (`/clients`, `/cloudservice`).

---

## Próximos passos:
- Criar endpoints para gerenciar contratos de uso (`UsageContract`) e expandir o relacionamento Many-to-Many:
- Exemplo: "Listar serviços contratados por um cliente" ou "Listar clientes que utilizam um serviço".
- Implementar consultas personalizadas com filtros (ex.: contratos ativos, por data de início, etc.).
- Melhorar o tratamento de erros com mensagens mais detalhadas e status HTTP adequados (`400`, `404`, etc.).
